### PR TITLE
Brute force stop

### DIFF
--- a/service/config/config_example.ini
+++ b/service/config/config_example.ini
@@ -13,8 +13,10 @@ sumaserver.log.path =
 sumaserver.log.name = sumaserver.log
 
 ; Admin Login
-sumaserver.admin.user   = admin
-sumaserver.admin.pass   = admin
+sumaserver.admin.user          = admin
+sumaserver.admin.pass          = admin
+sumaserver.admin.lockout_count = 5
+sumaserver.admin.lockout_time  = 300
 
 ; Query Server
 queryserver.db.limit    = 10000

--- a/service/config/config_example.yaml
+++ b/service/config/config_example.yaml
@@ -32,6 +32,8 @@ production:
         admin:
             user: admin
             pass: admin
+            lockout_count: 5
+            lockout_time: 300
     queryserver:
         db:
             limit: 10000

--- a/service/config/schema.sql
+++ b/service/config/schema.sql
@@ -102,6 +102,13 @@ CREATE TABLE IF NOT EXISTS `note` (
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB ;
 
+CREATE TABLE IF NOT EXISTS `userLock` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `time` INT UNSIGNED NOT NULL,
+    `username` VARCHAR(50) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB ;
+
 CREATE INDEX transStart ON transaction(start);
 CREATE INDEX transEnd ON transaction(end);
 CREATE INDEX sessionStart ON session(start);

--- a/service/controllers/AdminController.php
+++ b/service/controllers/AdminController.php
@@ -24,7 +24,7 @@ class AdminController extends BaseController
       $user = Zend_Filter::filterStatic($this->getRequest()->getParam('username'), 'StripTags');
       $pass = Zend_Filter::filterStatic($this->getRequest()->getParam('password'), 'StripTags');
 
-      if ($this->checkAuthCount($user) >= 5) {
+      if ($this->checkAuthCount($user) >= Globals::getConfig()->sumaserver->admin->lockout_count) {
         $this->lockedOut();
       }
       else {
@@ -436,12 +436,14 @@ class AdminController extends BaseController
 
     private function checkAuthCount($user) {
 
+        $lockoutTime  = Globals::getConfig()->sumaserver->admin->lockout_time;
+
         // Check to see if this user 'locked out'
         // There isn't a true user model, so we are just performing the logic here
         $_db    = Globals::getDBConn();
         $select = $_db->select()
                     ->from('userLock')
-                    ->where(sprintf("`username`='%s' AND`time`>='%s'",$user,(time() - 300)));
+                    ->where(sprintf("`username`='%s' AND`time`>='%s'",$user,(time() - $lockoutTime)));
 
         $query = $select->query();
         $count = 0;


### PR DESCRIPTION
Provides a basic mechanism for locking a user account after a number of failed locking attempts. This will help to prevent against brute force password cracking attempts of the admin account.

Lockout configuration has been added to the service/config/config_example.\* files. The default values are 5 attempts in 5 minutes.

To disable, change the lockout_count to a sufficiently high number, such as 1000.
