### PR TITLE
Sticky Buttons

### DIFF
--- a/service/config/schema.sql
+++ b/service/config/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS `activity_group` (
     `description` LONGTEXT NULL,
     `required` BOOLEAN NOT NULL DEFAULT false,
     `allowMulti` BOOLEAN NOT NULL DEFAULT true,
+    `sticky` BOOLEAN NOT NULL DEFAULT false,
     `fk_initiative` INT NOT NULL,
     FOREIGN KEY (fk_initiative) REFERENCES initiative (id),
     PRIMARY KEY (`id`)

--- a/service/config/schema_w_sample.sql
+++ b/service/config/schema_w_sample.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS `activity_group` (
     `description` LONGTEXT NULL,
     `required` BOOLEAN NOT NULL DEFAULT false,
     `allowMulti` BOOLEAN NOT NULL DEFAULT true,
+    `sticky` BOOLEAN NOT NULL DEFAULT false,
     `fk_initiative` INT NOT NULL,
     FOREIGN KEY (fk_initiative) REFERENCES initiative (id),
     PRIMARY KEY (`id`)

--- a/service/models/ActivityGroupModel.php
+++ b/service/models/ActivityGroupModel.php
@@ -117,7 +117,8 @@ class ActivityGroupModel
                       'rank'         =>  $data['rank'],
                       'description'  =>  $data['desc'],
                       'required'     =>  (int)$data['required'],
-                      'allowMulti'   =>  (int)$data['allowMulti']);
+                      'allowMulti'   =>  (int)$data['allowMulti'],
+                      'sticky'       =>  (int)$data['sticky']);
 
         $this->_db->update('activity_group', $hash, 'id = '.$this->_id);
         Globals::getLog()->info('ACTIVITY GROUP UPDATED - id: '.$this->_id.', title: '.$data['title']);
@@ -146,6 +147,7 @@ class ActivityGroupModel
                       'description'    =>  isset($data['descr']) ? $data['descr'] : null,
                       'required'       =>  isset($data['required']) ? (int)$data['required'] : 0,
                       'allowMulti'     =>  isset($data['allowMulti']) ? (int)$data['allowMulti'] : 1,
+                      'sticky'         =>  isset($data['sticky']) ? (int)$data['sticky'] : 0,
                       'fk_initiative'  =>  $data['init']);
 
         $select = $db->select()

--- a/service/models/ActivityModel.php
+++ b/service/models/ActivityModel.php
@@ -158,14 +158,15 @@ class ActivityModel
 
                 if ((isset($activityGroup['title']) && strlen($activityGroup['title']) > 0) && isset($activityGroup['id'])
                     && isset($activityGroup['desc'])  && (isset($activityGroup['required']))
-                    && (isset($activityGroup['allowMulti'])))
+                    && (isset($activityGroup['allowMulti']))  && (isset($activityGroup['sticky'])))
                 {
                     $actGroupData = Array(
                         'title'    => $activityGroup['title'],
                         'desc'     => $activityGroup['desc'],
                         'rank'     => $actGroupKey,
                         'required' => (int)$activityGroup['required'],
-                        'allowMulti' => (int)$activityGroup['allowMulti']
+                        'allowMulti' => (int)$activityGroup['allowMulti'],
+                        'sticky' => (int)$activityGroup['sticky']
                         );
 
                     if (is_numeric($activityGroup['id']))
@@ -229,7 +230,7 @@ class ActivityModel
                         }
                     }
                 } else {
-                    throw new Exception('Missing required activity group fields (title, ID, required, allowMulti, or desc)');
+                    throw new Exception('Missing required activity group fields (title, ID, required, allowMulti, sticky, or desc)');
                 }
             }
             $db->commit();

--- a/service/models/InitiativeModel.php
+++ b/service/models/InitiativeModel.php
@@ -286,6 +286,7 @@ class InitiativeModel
                              'rank'     => (int)$group->getMetadata('rank'),
                              'required' => ($group->getMetadata('required')) ? true : false,
                              'allowMulti' => ($group->getMetadata('allowMulti')) ? true : false,
+                             'sticky'     => ($group->getMetadata('sticky')) ? true : false
                              );
         }
 

--- a/service/models/QueryModel.php
+++ b/service/models/QueryModel.php
@@ -134,7 +134,7 @@ class QueryModel
             $select = $this->_db->select()
                 ->distinct()
                 ->from(array('ag' => 'activity_group'),
-                       array('id', 'title', 'rank', 'description', 'required', 'allowMulti'))
+                       array('id', 'title', 'rank', 'description', 'required', 'allowMulti','sticky'))
                 ->join(array('a' => 'activity'),
                        'a.fk_activity_group = ag.id',
                         array())
@@ -146,7 +146,7 @@ class QueryModel
             {
                 foreach($grp as $key => $val)
                 {
-                    if (($key === 'required') || ($key === 'allowMulti'))
+                    if (($key === 'required') || ($key === 'allowMulti') || ($key === 'sticky'))
                     {
                         $grp[$key] = ($val == 1 || $val == TRUE) ? TRUE : FALSE;
                     } else if (is_numeric($val))
@@ -164,7 +164,8 @@ class QueryModel
                 'rank'  => 9999,
                 'description' => '',
                 'required' => 0,
-                'allowedMulti' => 0
+                'allowedMulti' => 0,
+                'sticky' => 0
             );
         }
 

--- a/service/views/scripts/admin/initiativeload.phtml
+++ b/service/views/scripts/admin/initiativeload.phtml
@@ -21,8 +21,9 @@ $activityGroups = $this->init->getActivityGroups(FALSE);
 foreach ($activityGroups as $activityGroup) {
     $actGroupRequired = ($activityGroup->getMetadata('required')) ? 'required-act-group' : '';
     $actGroupAllowMulti = ($activityGroup->getMetadata('allowMulti')) ? 'allowMulti-act-group' : '';
+    $actGroupSticky = ($activityGroup->getMetadata('sticky')) ? 'sticky-act-group' : '';
 
-    echo "<li class=\"activityGroup {$actGroupRequired} {$actGroupAllowMulti}\"><div><span class=\"actGroupTitle\">".$activityGroup->getMetadata('title') .
+    echo "<li class=\"activityGroup {$actGroupRequired} {$actGroupAllowMulti} {$actGroupSticky}\"><div><span class=\"actGroupTitle\">".$activityGroup->getMetadata('title') .
         "</span> <span class=\"actGroupDesc\">".$activityGroup->getMetadata('description') .
         "</span><span class=\"actGroupID\">{$activityGroup->getMetadata('id')}</span><span class=\"activityControls\">" .
         "<a href=\"#\" class=\"addActivity\">Add Activity</a><a href=\"#\" class=\"editActGroup\">Edit</a></span></div>\n";

--- a/service/views/scripts/admin/initiatives.phtml
+++ b/service/views/scripts/admin/initiatives.phtml
@@ -58,6 +58,7 @@
                 <div id="activityGroupFormContent">
                     <span id="requiredGroupInput"><br>Required for data collection? <input name="actGroupRequiredCheck" type="checkbox" id="actGroupRequiredCheck" /><br></span>
                     <span id="allowMultiGroupInput"><br>Allow multiple activities? <input name="actGroupMultiCheck" type="checkbox" id="actGroupMultiCheck" /><br></span>
+                    <span id="allowStickyInput"><br>Make buttons sticky? <input name="actGroupStickyCheck" type="checkbox" id="actGroupStickyCheck" /><br></span>
                 </div>
             </form>
             <p>Activity edits will not be permanent until the entire activity list is saved.</p>

--- a/service/web/js/views/admin/initiatives.js
+++ b/service/web/js/views/admin/initiatives.js
@@ -188,7 +188,7 @@ $(document).ready(function(){
     });
 
     $("body").on("click", "a.editAct, a.editActGroup", function() {
-        var actLi, actEnabledCheck, titleSib, descSib, actTitleInput, actDescInput, actGroupRequiredCheck, actGroupMultiCheck;
+        var actLi, actEnabledCheck, titleSib, descSib, actTitleInput, actDescInput, actGroupRequiredCheck, actGroupMultiCheck, actGroupStickyCheck;
 
         actLi = $(this).closest("li")[0];
         actEnableArea = $("#enableInput")[0];
@@ -197,6 +197,7 @@ $(document).ready(function(){
         actDescInput = $("textarea#actDescInput")[0];
         actGroupRequiredCheck = $("#actGroupRequiredCheck");
         actGroupMultiCheck = $("#actGroupMultiCheck");
+        actGroupStickyCheck = $("#actGroupStickyCheck");
 
         if ($(this).hasClass("editActGroup")) {
             titleSib = $(actLi).children("div").children("span.actGroupTitle")[0];
@@ -215,6 +216,12 @@ $(document).ready(function(){
                 $(actGroupMultiCheck).attr("checked", "checked");
             } else {
                 $(actGroupMultiCheck).removeAttr("checked");
+            }
+
+            if ($(actLi).hasClass("sticky-act-group")){
+                $(actGroupStickyCheck).attr("checked", "checked");
+            } else {
+                $(actGroupStickyCheck).removeAttr("checked");
             }
 
             $(activityGroupFormContent).show();
@@ -284,6 +291,12 @@ $(document).ready(function(){
                                 $(actLi).addClass("allowMulti-act-group");
                             } else {
                                 $(actLi).removeClass("allowMulti-act-group");
+                            }
+
+                            if ($(actGroupStickyCheck).is(":checked")) {
+                                $(actLi).addClass("sticky-act-group");
+                            } else {
+                                $(actLi).removeClass("sticky-act-group");
                             }
 
                         } else {
@@ -371,6 +384,7 @@ $(document).ready(function(){
                 desc: _.escape($(this).find("span.actGroupDesc").text()),
                 required: $(this).hasClass("required-act-group"),
                 allowMulti: $(this).hasClass("allowMulti-act-group"),
+                sticky: $(this).hasClass("sticky-act-group"),
                 activities: []
             };
 

--- a/web/includes/js/spaceassess.js
+++ b/web/includes/js/spaceassess.js
@@ -194,6 +194,7 @@ function displayActivities(actInit, callback) {
             currentActivityGroup = $('<div class="activityGroup clearfix"><h5 class="actGroupLabel">' + activityGroup.title + '</h5></div>').appendTo(activityContainer);
             (true === activityGroup.required) ? currentActivityGroup.addClass('requiredGroup') : false;
             (true === activityGroup.allowMulti) ? currentActivityGroup.addClass('allowMulti') : false;
+            (true === activityGroup.sticky) ? currentActivityGroup.addClass('sticky') : false;
 
             leftActivity = $('<div class="leftActivities activityContainer"></div>').appendTo(currentActivityGroup);
             rightActivity = $('<div class="rightActivities activityContainer"></div>').appendTo(currentActivityGroup);
@@ -278,7 +279,7 @@ function fetchLocsActivities(init, callback)
 
                 $.each(locData["activityGroups"], function(key, activityGroup) {
                     var newActGroup = new ActivityGroup({title: activityGroup["title"], serverId: activityGroup["id"],
-                        rank: activityGroup["rank"], required: activityGroup["required"], allowMulti: activityGroup["allowMulti"]});
+                        rank: activityGroup["rank"], required: activityGroup["required"], allowMulti: activityGroup["allowMulti"], sticky: activityGroup["sticky"]});
                     newActGroup.initiative = init;
                     persistence.add(newActGroup);
                     activityGroups[activityGroup["id"]] = newActGroup;
@@ -581,8 +582,13 @@ function countPeople(doubleTap) {
 
         var countObj = new Person({timestamp:date.getTime()});
         $("input.check:checked", countForm).each(function() {
-            countObj.activities.add(currentActivities[$(this).val()]);
-        }).prop("checked", false).button("refresh");
+          var activityGroup
+          activityGroup = $(this).closest(".activityGroup");
+          countObj.activities.add(currentActivities[$(this).val()]);
+          if (!activityGroup.hasClass("sticky")) {
+            $(this).prop("checked", false).button("refresh");
+          }
+        });
         countObj.location = currentLoc;
         countObj.session = currentSession;
         countObj.count = newCount;

--- a/web/includes/js/spaceassessDB.js
+++ b/web/includes/js/spaceassessDB.js
@@ -59,7 +59,8 @@ function initSADB(callback) {
         title: "TEXT",
         required: "BOOL",
         rank: "INT",
-        allowMulti: "BOOL"
+        allowMulti: "BOOL",
+        sticky: "BOOL"
     });
 
     Person = persistence.define('Person', {


### PR DESCRIPTION
This adds an option for making buttons within activity groups "sticky." If sticky buttons are enabled for an activity group in the admin interface, activities in those groups do not clear when users hit the Count button on the client side.

Use case: Instead of just a raw headcount, we count the number of people in the library who are working independently and how many are working in groups. This allows us to more quickly count without having to reselect the "individual" or "group" activity button for every single person.
