### PR TITLE
add docker scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+FROM php:7.0-apache
+
+# Configuration
+ENV SUMA_WEB_DIR /var/www/html
+ENV SUMA_APP_DIR /var/www/app
+ENV SUMA_LOG_PATH /var/log/suma/
+ENV SUMA_ADMIN_USER admin
+ENV SUMA_ADMIN_PASSWORD suma
+ENV SUMA_DEBUG false
+ENV TZ America/Los_Angeles
+
+# Database configuration
+ENV SUMA_DB_HOST localhost
+ENV SUMA_DB_PLATFORM Pdo_Mysql
+ENV SUMA_DB_NAME suma
+ENV SUMA_DB_USER admin
+ENV SUMA_DB_PASSWORD suma
+ENV SUMA_DB_PORT 3306
+
+# Install dependencies
+RUN docker-php-ext-install pdo_mysql
+
+# Install suma server & client
+RUN mkdir -p "$SUMA_WEB_DIR/suma/web" \
+             "$SUMA_WEB_DIR/suma/analysis" \
+             "$SUMA_APP_DIR/sumaserver" \
+             "$SUMA_WEB_DIR/sumaserver"
+COPY web "$SUMA_WEB_DIR/suma/web"
+COPY analysis "$SUMA_WEB_DIR/suma/analysis"
+COPY service "$SUMA_APP_DIR/sumaserver"
+COPY service/web "$SUMA_WEB_DIR/sumaserver"
+
+# Configure apache
+COPY suma.conf /etc/apache2/sites-available
+RUN a2enmod rewrite
+RUN a2ensite suma
+RUN a2dissite 000-default
+WORKDIR "$SUMA_WEB_DIR/sumaserver"
+RUN mv htaccess_example .htaccess
+
+# Configure suma server
+RUN mv config/config_example.yaml config/config.yaml
+RUN sed -i 's@SUMA_SERVER_PATH.*@SUMA_SERVER_PATH: '"$SUMA_APP_DIR"'\/sumaserver@' config/config.yaml
+RUN sed -i 's@SUMA_CONTROLLER_PATH.*@SUMA_CONTROLLER_PATH: '"$SUMA_APP_DIR"'\/sumaserver\/controllers@' config/config.yaml
+RUN sed -i 's@SUMA_BASE_URL.*@SUMA_BASE_URL: \/sumaserver@' config/config.yaml
+WORKDIR "$SUMA_APP_DIR/sumaserver"
+RUN mv config/config_example.yaml config/config.yaml
+RUN mv config/session_example.yaml config/session.yaml
+RUN sed -i 's@cookie_path:.*@cookie_path: \/sumaserver@' config/session.yaml
+RUN mkdir -p "$SUMA_LOG_PATH"
+RUN chown www-data "$SUMA_LOG_PATH"
+
+# Configure suma client
+WORKDIR "$SUMA_WEB_DIR/suma/web"
+RUN mv config/spaceassessConfig_example.js config/spaceassessConfig.js
+
+# Configure suma analysis tools
+WORKDIR "$SUMA_WEB_DIR/suma/analysis"
+RUN mv config/config_example.yaml config/config.yaml
+RUN sed -i 's@baseUrl:.*@baseUrl: http:\/\/localhost\/sumaserver\/query@' config/config.yaml
+RUN sed -i 's@analysisBaseUrl:.*@analysisBaseUrl: http:\/\/localhost\/suma\/analysis\/reports@' config/config.yaml
+
+# Run the app
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+
+services:
+
+  db:
+    image: mysql:latest
+    volumes:
+      - ./.data/db:/var/lib/mysql
+      - ./service/config/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    environment:
+      MYSQL_ROOT_PASSWORD: suma
+      MYSQL_DATABASE: suma
+      MYSQL_USER: admin
+      MYSQL_PASSWORD: suma
+
+  suma:
+    build: .
+    links:
+      - db
+    ports:
+      - "8081:80"
+    environment:
+      TZ: America/Los_Angeles
+      SUMA_DB_HOST: db
+      SUMA_DEBUG: 'true'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = 'apache2' ]; then
+    # set suma server config
+    cd "$SUMA_APP_DIR/sumaserver"
+    sed -i 's@host.*$@host: '"$SUMA_DB_HOST"'@' config/config.yaml
+    sed -i 's@platform.*$@platform: '"$SUMA_DB_PLATFORM"'@' config/config.yaml
+    sed -i 's@dbname.*$@dbname: '"$SUMA_DB_NAME"'@' config/config.yaml
+    sed -i 's@DB_USERNAME@'"$SUMA_DB_USER"'@' config/config.yaml
+    sed -i 's@DB_PASSWORD@'"$SUMA_DB_PASSWORD"'@' config/config.yaml
+    sed -i 's@port.*$@port: '"$SUMA_DB_PORT"'@' config/config.yaml
+    sed -i 's@path.*$@path: '"$SUMA_LOG_PATH"'@' config/config.yaml
+    sed -i 's@user: admin@user: '"$SUMA_ADMIN_USER"'@' config/config.yaml
+    sed -i 's@pass: admin@pass: '"$SUMA_ADMIN_PASSWORD"'@' config/config.yaml
+    # set log level
+    cd "$SUMA_WEB_DIR/sumaserver"
+    sed -i 's@SUMA_DEBUG:.*@SUMA_DEBUG: '"$SUMA_DEBUG"'@' config/config.yaml
+    # set timezone
+    echo -e "date.timezone = \"$TZ\"" >> /usr/local/etc/php/conf.d/php.ini
+    # start server
+    source /etc/apache2/envvars
+    exec apache2 -D FOREGROUND
+fi
+
+exec "$@"

--- a/suma.conf
+++ b/suma.conf
@@ -1,0 +1,12 @@
+<VirtualHost *:80>
+
+    DocumentRoot "${SUMA_WEB_DIR}"
+    ServerName localhost
+
+    <Directory "${SUMA_WEB_DIR}">
+        Options Indexes FollowSymLinks MultiViews
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+</VirtualHost>


### PR DESCRIPTION
this PR adds scripts for building the full suma stack (server + client) as a [docker](https://www.docker.com/) image, and an example [compose](https://docs.docker.com/compose/) file for running the application with a linked mysql database.

the suma install process seemed complex, with a number of directories to mentally manage, so I put this together in case anyone might benefit from using a prebuilt docker image instead.

the installation can be customized by editing the `Configuration` section of the Dockerfile and rebuilding with something like:
```sh
docker build -t ncsulibrariesdli/suma .
```
some of the config values can be changed at runtime, e.g. `SUMA_DEBUG`, as shown in the compose file.

if docker and docker-compose are installed, running the full app is as easy as:
```sh
docker-compose up -d
```

if this isn't useful; no big deal - just thought i would file the PR in case the project is still active and it would help someone.