### PR TITLE
Add Zend Path Explicitly

### DIFF
--- a/service/web/index.php
+++ b/service/web/index.php
@@ -38,7 +38,7 @@ else
 ini_set('display_errors', $SUMA_DISPLAY_ERRORS);
 
 // Set paths
-ini_set('include_path', ini_get('include_path') . PATH_SEPARATOR . PATH_SEPARATOR. $SUMA_SERVER_PATH . '/service' . PATH_SEPARATOR . $SUMA_SERVER_PATH . '/service/lib/zend/library');
+ini_set('include_path', ini_get('include_path') . PATH_SEPARATOR . $SUMA_SERVER_PATH . '/service' . PATH_SEPARATOR . $SUMA_SERVER_PATH . '/service/lib/zend/library');
 
 try
 {

--- a/service/web/index.php
+++ b/service/web/index.php
@@ -38,7 +38,7 @@ else
 ini_set('display_errors', $SUMA_DISPLAY_ERRORS);
 
 // Set paths
-ini_set('include_path', ini_get('include_path') . PATH_SEPARATOR . $SUMA_SERVER_PATH . PATH_SEPARATOR . $SUMA_SERVER_PATH . '/lib/zend/library');
+ini_set('include_path', ini_get('include_path') . PATH_SEPARATOR . PATH_SEPARATOR. $SUMA_SERVER_PATH . '/service' . PATH_SEPARATOR . $SUMA_SERVER_PATH . '/service/lib/zend/library');
 
 try
 {
@@ -105,3 +105,5 @@ catch (Exception $e)
     print $e->getMessage();
     die;
 }
+
+?>


### PR DESCRIPTION
Hello,

First, thank you for your work on this project! I am excited to be testing it!

I'm using a [dockerized](https://github.com/Tutt-Library/suma-docker) Suma (similar to PR #71, which I hadn't seen), but am getting the following error when visiting `/sumaserver` in my browser:

```
Warning: include_once(Zend/Loader.php): failed to open stream: No such file or directory in /var/www/app/sumaserver/service/web/index.php on line 46

Warning: include_once(): Failed opening 'Zend/Loader.php' for inclusion (include_path='.:/usr/share/php:/var/www/app/sumaserver:/var/www/app/sumaserver/lib/zend/library') in /var/www/app/sumaserver/service/web/index.php on line 46
Trouble loading Suma server application. This is often caused by configuration issues. Please refer to the troubleshooting docs at http://suma-project.github.io/Suma The raw output is below: Possible error in SUMA_SERVER_PATH.
```

Thus, this Pull Request explicitly names the location of the Zend dependency, which corrects the error.