### PR TITLE
Updating symlink installation documentation

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -34,13 +34,13 @@ Suma Software Installation (symbolic links, **RECOMMENDED**)
 If your Apache configuration has the `FollowSymLinks` directive enabled, there is a simpler way to deploy Suma that also improves the update process.
 
 * Clone the GitHub repository to a directory outside of your web space (e.g. `/var/www/app/suma`)
+* Create `/var/www/html/suma` (e.g., `mkdir /var/www/html/suma`)
 * Create the following symbolic links from your web space to the local suma repository (these instructions make several assumptions about paths and directory names--please change as needed, noting the configuration directions later in this document):
 
-
-        /var/www/htdocs/sumaserver/      =>  /var/www/app/suma/service/web/
-        /var/www/htdocs/suma/client/        =>  /var/www/app/suma/web/
-        /var/www/htdocs/suma/analysis/   =>  /var/www/app/suma/analysis/
-
+        ln -s /var/www/app/suma/service /var/www/app/sumaserver
+        ln -s /var/www/app/suma/service/web /var/www/html/sumaserver
+        ln -s /var/www/app/suma/web /var/www/html/suma/web
+        ln -s /var/www/app/suma/analysis /var/www/html/suma/analysis
 
 Now all of your code is in one place, allowing you to update Suma by running `git pull --rebase origin master`. There is a chance this could result in merge conflicts with your local changes, so please allow for time to resolve these before updating.
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -17,7 +17,7 @@ These requirements are based on our local testing. Earlier versions may also wor
 * Zend Framework 1.12 - required for Suma server, included with Suma code
 * Various Javascript Libraries - all included with Suma code
 * For Apache, enable the following modules:
-    * `a2enmod phpXXX`, where XXX is the installed PHP version (e.g., `php7.0`).
+    * `a2enmod phpXXX`, where XXX is the installed PHP version (e.g., `php5.0`).
     * `a2enmod rewrite`
     * `phpenmod pdo_mysql`
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -17,7 +17,7 @@ These requirements are based on our local testing. Earlier versions may also wor
 * Zend Framework 1.12 - required for Suma server, included with Suma code
 * Various Javascript Libraries - all included with Suma code
 * For Apache, enable the following modules:
-    * `a2enmod phpXXX`, where XXX is the installed PHP version (e.g., `php5.0`).
+    * `a2enmod phpXXX`, where XXX is the installed PHP version (e.g., `php7.0`).
     * `a2enmod rewrite`
     * `phpenmod pdo_mysql`
 
@@ -38,13 +38,13 @@ Suma Software Installation (symbolic links, **RECOMMENDED**)
 If your Apache configuration has the `FollowSymLinks` directive enabled, there is a simpler way to deploy Suma that also improves the update process.
 
 * Clone the GitHub repository to a directory outside of your web space (e.g. `/var/www/app/suma`)
-* Create `/var/www/html/suma` (e.g., `mkdir /var/www/html/suma`)
+* Create `/var/www/htdocs/suma` (e.g., `mkdir /var/www/htdocs/suma`)
 * Create the following symbolic links from your web space to the local suma repository (these instructions make several assumptions about paths and directory names--please change as needed, noting the configuration directions later in this document):
 
         ln -s /var/www/app/suma/service /var/www/app/sumaserver
-        ln -s /var/www/app/suma/service/web /var/www/html/sumaserver
-        ln -s /var/www/app/suma/web /var/www/html/suma/web
-        ln -s /var/www/app/suma/analysis /var/www/html/suma/analysis
+        ln -s /var/www/app/suma/service/web /var/www/htdocs/sumaserver
+        ln -s /var/www/app/suma/web /var/www/htdocs/suma/web
+        ln -s /var/www/app/suma/analysis /var/www/htdocs/suma/analysis
 
 Now all of your code is in one place, allowing you to update Suma by running `git pull --rebase origin master`. There is a chance this could result in merge conflicts with your local changes, so please allow for time to resolve these before updating.
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -16,6 +16,10 @@ These requirements are based on our local testing. Earlier versions may also wor
 * PHP required version of at least 5.3.3 (including cURL, mbstring, PDO, and DOM). ** Please note that different server operating systems may use different module names. If you are experiencing unexpected issues with Suma after installation, check your server logs for missing PHP modules.** See the development environment for Suma, [Suma-Vagrant](https://github.com/suma-project/Suma-Vagrant/blob/master/ansible/roles/demo/tasks/server.yml#L23-L57), for a full list of required PHP modules.
 * Zend Framework 1.12 - required for Suma server, included with Suma code
 * Various Javascript Libraries - all included with Suma code
+* For Apache, enable the following modules:
+    * `a2enmod phpXXX`, where XXX is the installed PHP version (e.g., `php7.0`).
+    * `a2enmod rewrite`
+    * `phpenmod pdo_mysql`
 
 Additional Client Requirements:
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -41,7 +41,6 @@ If your Apache configuration has the `FollowSymLinks` directive enabled, there i
 * Create `/var/www/htdocs/suma` (e.g., `mkdir /var/www/htdocs/suma`)
 * Create the following symbolic links from your web space to the local suma repository (these instructions make several assumptions about paths and directory names--please change as needed, noting the configuration directions later in this document):
 
-        ln -s /var/www/app/suma/service /var/www/app/sumaserver
         ln -s /var/www/app/suma/service/web /var/www/htdocs/sumaserver
         ln -s /var/www/app/suma/web /var/www/htdocs/suma/web
         ln -s /var/www/app/suma/analysis /var/www/htdocs/suma/analysis
@@ -61,7 +60,7 @@ For Suma Client Installation:
 
 For Suma Server Installation:
 
-* Copy contents of `/SUMA_DOWNLOAD_DIR/service` to a location outside your web directory. For example, if your web directory is `/var/www/htdocs` you could copy the contents of the `/SUMA_DOWNLOAD_DIR/service` to `/var/www/app/sumaserver`.
+* Copy contents of `/SUMA_DOWNLOAD_DIR/service` to a location outside your web directory. For example, if your web directory is `/var/www/htdocs` you could copy the contents of the `/SUMA_DOWNLOAD_DIR/service` to `/var/www/app/suma/service`.
 
     Note this location, we will refer to it later as `SUMA_SERVER_INSTALL_DIR`
 
@@ -129,9 +128,9 @@ Suma Server Software Configuration
 
     In the `/SUMA_SERVER_INSTALL_DIR/web/config/` directory, copy `config_example.yaml` to a new file `config.yaml`. You must set some path variables in the `config.yaml` file for the Suma server to function correctly.
 
-    `SUMA_SERVER_PATH` must be set to the `SUMA_SERVER_INSTALL_DIR` where the Suma server was installed earlier in these instructions (e.g. `/var/www/app/sumaserver`).
+    `SUMA_SERVER_PATH` must be set to the `SUMA_SERVER_INSTALL_DIR` where the Suma server was installed earlier in these instructions (e.g. `/var/www/app/suma/service`).
 
-    `SUMA_CONTROLLER_PATH` must be set to `SUMA_SERVER_INSTALL_DIR/controllers` (e.g. `/var/www/app/sumaserver/controllers`).
+    `SUMA_CONTROLLER_PATH` must be set to `SUMA_SERVER_INSTALL_DIR/controllers` (e.g. `/var/www/app/suma/service/controllers`).
 
     `SUMA_BASE_URL` must be set to the URL path for the Suma server. For example, if the URL is `http://YOUR_HOST/sumaserver`, set this to `/sumaserver`.
 

--- a/docs/docs/upgrade_1.0.md
+++ b/docs/docs/upgrade_1.0.md
@@ -66,9 +66,9 @@ The various configuration settings are listed below as `PREVIOUS_FILE` => `NEW_C
 
     In the `/SUMA_SERVER_INSTALL_DIR/web/config/` directory, copy `config_example.yaml` to a new file `config.yaml`. You must set some path variables in the `config.yaml` file for the Suma server to function correctly.
 
-    `SUMA_SERVER_PATH` must be set to the `SUMA_SERVER_INSTALL_DIR` where the Suma server was installed earlier in these instructions (e.g. `/var/www/app/sumaserver`).
+    `SUMA_SERVER_PATH` must be set to the `SUMA_SERVER_INSTALL_DIR` where the Suma server was installed earlier in these instructions (e.g. `/var/www/app/suma/service`).
 
-    `SUMA_CONTROLLER_PATH` must be set to `SUMA_SERVER_INSTALL_DIR/controllers` (e.g. `/var/www/app/sumaserver/controllers`).
+    `SUMA_CONTROLLER_PATH` must be set to `SUMA_SERVER_INSTALL_DIR/controllers` (e.g. `/var/www/app/suma/service/controllers`).
 
     `SUMA_BASE_URL` must be set to the URL path for the Suma server. For example, if the URL is `http://YOUR_HOST/sumaserver`, set this to `/sumaserver`.
 

--- a/service/config/config_example.ini
+++ b/service/config/config_example.ini
@@ -8,7 +8,7 @@ sumaserver.db.pword     = DB_PASSWORD
 sumaserver.db.port      = 3306
 
 ; Log
-; e.g. sumaserver.log.path = /var/www/app/sumaserver/service/logs/
+; e.g. sumaserver.log.path = /var/www/app/suma/service/service/logs/
 sumaserver.log.path =
 sumaserver.log.name = sumaserver.log
 


### PR DESCRIPTION
Following discussion in PR #76 and follow-up emails about it, I think now that the file-copying instructions and symlink creation instructions in Suma's installation documentation are not in sync with one another. Thus, this PR updates the documentation on creating symlinks in a way that no longer causes the Zend dependency error mentioned in #76.

As a related addition, it also makes explicit which Apache / PHP modules users may need to enable by default.