### PR TITLE
small css fix and support for alternative hostnames in dev

### DIFF
--- a/web-sourcecode/src/components/tree.vue
+++ b/web-sourcecode/src/components/tree.vue
@@ -112,7 +112,7 @@ import shared from './compontentFunctions'
   appearance: none;
   background: none!important;
   border: none;
-  word-break: break-all;
+  word-break: break-word;
   cursor: pointer;
 }
 </style>

--- a/web-sourcecode/vue.config.js
+++ b/web-sourcecode/vue.config.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   filenameHashing: false,
   devServer: {
+    disableHostCheck: true,
     proxy: {
       "/sumaserver/*": {
         target: "http://localhost:19679",


### PR DESCRIPTION
 - changed to word break to prevent odd wrapping on long location names
 - added support for alternative hostnames for the dev environment.  This allows a device on the same network as the npm server to use a computer's shortname rather than the full IP address.
