### PR TITLE
Don't display PHP notices during server debugging

### DIFF
--- a/service/web/index.php
+++ b/service/web/index.php
@@ -23,7 +23,7 @@ $SUMA_BASE_URL = $config['SUMA_BASE_URL'];
 // Debug Mode Setup
 if ($config['SUMA_DEBUG'] == true)
 {
-    $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING | E_PARSE | E_NOTICE;
+    $SUMA_ERROR_REPORTING  = E_ERROR | E_WARNING | E_PARSE;
     $SUMA_DISPLAY_ERRORS   = 'on';
     $SUMA_THROW_EXCEPTIONS =  true;
     error_reporting($SUMA_ERROR_REPORTING);


### PR DESCRIPTION
This will keep minor deprecation notices from breaking the server when debugging. We'll still need to address them eventually.