### PR TITLE
WIP: Fix old bug when accessing an int as an array

### DIFF
--- a/service/transformers/CalTransformer.php
+++ b/service/transformers/CalTransformer.php
@@ -79,8 +79,8 @@ class CalTransformer extends BaseTransformer
 
         foreach($activities as &$activity)
         {
-            if ((isset($row['act']) && $activity['id'] == $row['act']) ||
-                (! isset($row['act']) && $activity['id'] == $row[-1]))
+            if ((isset($row['act']) && $activity == $row['act']) ||
+                (! isset($row['act']) && $activity == $row[-1]))
             {
                 unset($activity);
                 return;

--- a/service/transformers/LcaTransformer.php
+++ b/service/transformers/LcaTransformer.php
@@ -107,7 +107,7 @@ class LcaTransformer extends BaseTransformer
         {
             foreach($activities as &$activity)
             {
-                if ($activity['id'] == $row['act'])
+                if ($activity == $row['act'])
                 {
                     unset($activity);
                     return null;
@@ -120,7 +120,7 @@ class LcaTransformer extends BaseTransformer
         {
             foreach($activities as &$activity)
             {
-                if ($activity['id'] == -1)
+                if ($activity == -1)
                 {
                     unset($activity);
                     return null;


### PR DESCRIPTION
This is due to an inconsistent representation of activities in different transformers. Thanks to Erik Mallory for catching this!

This still needs to be tested.